### PR TITLE
ci: add cuncurrency to GitHub Actions workflow [skip ci]

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   continuous_integration_build:
     continue-on-error: true


### PR DESCRIPTION
#### Why

This adds a concurrency group to GitHub Actions workflows.

More info on what it is can be found [here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency)
